### PR TITLE
Added functionality to provide single MSA file as input (.a3m format)…

### DIFF
--- a/AF_multitemplate/alphafold/data/pipeline.py
+++ b/AF_multitemplate/alphafold/data/pipeline.py
@@ -26,6 +26,7 @@ from alphafold.data.tools import hhsearch
 from alphafold.data.tools import hmmsearch
 from alphafold.data.tools import jackhmmer
 import numpy as np
+import sys
 
 # Internal import (7716).
 
@@ -123,38 +124,41 @@ class DataPipeline:
                uniref30_database_path: Optional[str],
                small_bfd_database_path: Optional[str],
                template_searcher: TemplateSearcher,
+               msa_file: str,
                template_featurizer: templates.TemplateHitFeaturizer,
                use_small_bfd: bool,
                mgnify_max_hits: int = 501,
                uniref_max_hits: int = 10000,
                bfd_max_hits: int = 10000,
-               input_msa: str = None,
                no_templates: bool = False,
                use_precomputed_msas: bool = False):
+    
     """Initializes the data pipeline."""
-    self._use_small_bfd = use_small_bfd
-    self.jackhmmer_uniref90_runner = jackhmmer.Jackhmmer(
-        binary_path=jackhmmer_binary_path,
-        database_path=uniref90_database_path)
-    if use_small_bfd:
-      self.jackhmmer_small_bfd_runner = jackhmmer.Jackhmmer(
+    if not msa_file:  # Dont check for databases if MSA file is provided
+      self._use_small_bfd = use_small_bfd
+      self.jackhmmer_uniref90_runner = jackhmmer.Jackhmmer(
           binary_path=jackhmmer_binary_path,
-          database_path=small_bfd_database_path)
-    else:
-      self.hhblits_bfd_uniref_runner = hhblits.HHBlits(
-          binary_path=hhblits_binary_path,
-          databases=[bfd_database_path, uniref30_database_path])
-    self.jackhmmer_mgnify_runner = jackhmmer.Jackhmmer(
-        binary_path=jackhmmer_binary_path,
-        database_path=mgnify_database_path)
+          database_path=uniref90_database_path)
+      if use_small_bfd:
+        self.jackhmmer_small_bfd_runner = jackhmmer.Jackhmmer(
+            binary_path=jackhmmer_binary_path,
+            database_path=small_bfd_database_path)
+      else:
+        self.hhblits_bfd_uniref_runner = hhblits.HHBlits(
+            binary_path=hhblits_binary_path,
+            databases=[bfd_database_path, uniref30_database_path])
+      self.jackhmmer_mgnify_runner = jackhmmer.Jackhmmer(
+          binary_path=jackhmmer_binary_path,
+          database_path=mgnify_database_path)
+      
     self.template_searcher = template_searcher
     self.template_featurizer = template_featurizer
     self.mgnify_max_hits = mgnify_max_hits
     self.uniref_max_hits = uniref_max_hits
     self.bfd_max_hits = bfd_max_hits
-    self.input_msa=input_msa
     self.no_templates=no_templates
     self.use_precomputed_msas = use_precomputed_msas
+    self.msa_file = msa_file
 
   def process(self, input_fasta_path: str, msa_output_dir: str) -> FeatureDict:
     """Runs alignment tools on the input sequence and creates features."""
@@ -168,98 +172,122 @@ class DataPipeline:
     input_description = input_descs[0]
     num_res = len(input_sequence)
 
-    uniref90_out_path = os.path.join(msa_output_dir, 'uniref90_hits.sto')
-    jackhmmer_uniref90_result = run_msa_tool(
-        msa_runner=self.jackhmmer_uniref90_runner,
-        input_fasta_path=input_fasta_path,
-        msa_out_path=uniref90_out_path,
-        msa_format='sto',
-        use_precomputed_msas=self.use_precomputed_msas,
-        max_sto_sequences=self.uniref_max_hits)
-    mgnify_out_path = os.path.join(msa_output_dir, 'mgnify_hits.sto')
-    jackhmmer_mgnify_result = run_msa_tool(
-        msa_runner=self.jackhmmer_mgnify_runner,
-        input_fasta_path=input_fasta_path,
-        msa_out_path=mgnify_out_path,
-        msa_format='sto',
-        use_precomputed_msas=self.use_precomputed_msas,
-        max_sto_sequences=self.mgnify_max_hits)
-
-    msa_for_templates = jackhmmer_uniref90_result['sto']
-    msa_for_templates = parsers.deduplicate_stockholm_msa(msa_for_templates)
-    msa_for_templates = parsers.remove_empty_columns_from_stockholm_msa(
-        msa_for_templates)
-
-    pdb_hits_out_path = os.path.join(
-        msa_output_dir, f'pdb_hits.{self.template_searcher.output_format}')
-    if self.no_templates:
-      logging.info(f'Using no template information at all (--no_templates is {self.no_templates})')
-      pdb_template_hits=[]
-      pdb_templates_result=""
-    else:
-      if not self.use_precomputed_msas or not os.path.isfile(pdb_hits_out_path):
-        if self.template_searcher.input_format == 'sto':
-          pdb_templates_result = self.template_searcher.query(msa_for_templates)
-        elif self.template_searcher.input_format == 'a3m':
-          uniref90_msa_as_a3m = parsers.convert_stockholm_to_a3m(msa_for_templates)
-          pdb_templates_result = self.template_searcher.query(uniref90_msa_as_a3m)
-        else:
-          raise ValueError('Unrecognized template input format: '
-                        f'{self.template_searcher.input_format}')
-        with open(pdb_hits_out_path, 'w') as f:
-          f.write(pdb_templates_result)
-      else: # read a pre-existing pdb_hits.sto file
-        with open(pdb_hits_out_path) as f:
-          pdb_templates_result = f.read()
-      pdb_template_hits = self.template_searcher.get_template_hits(
-        output_string=pdb_templates_result, input_sequence=input_sequence)
-     
-
-    uniref90_msa = parsers.parse_stockholm(jackhmmer_uniref90_result['sto'])
-    mgnify_msa = parsers.parse_stockholm(jackhmmer_mgnify_result['sto'])
-
-    pdb_template_hits = self.template_searcher.get_template_hits(
-        output_string=pdb_templates_result, input_sequence=input_sequence)
-
-    if self._use_small_bfd:
-      bfd_out_path = os.path.join(msa_output_dir, 'small_bfd_hits.sto')
-      jackhmmer_small_bfd_result = run_msa_tool(
-          msa_runner=self.jackhmmer_small_bfd_runner,
+    if not self.msa_file:
+      uniref90_out_path = os.path.join(msa_output_dir, 'uniref90_hits.sto')
+      jackhmmer_uniref90_result = run_msa_tool(
+          msa_runner=self.jackhmmer_uniref90_runner,
           input_fasta_path=input_fasta_path,
-          msa_out_path=bfd_out_path,
+          msa_out_path=uniref90_out_path,
           msa_format='sto',
           use_precomputed_msas=self.use_precomputed_msas,
-          max_sto_sequences=self.bfd_max_hits)
-      bfd_msa = parsers.parse_stockholm(jackhmmer_small_bfd_result['sto'])
-    else:
-      bfd_out_path = os.path.join(msa_output_dir, 'bfd_uniref_hits.a3m')
-      hhblits_bfd_uniref_result = run_msa_tool(
-          msa_runner=self.hhblits_bfd_uniref_runner,
+          max_sto_sequences=self.uniref_max_hits)
+      mgnify_out_path = os.path.join(msa_output_dir, 'mgnify_hits.sto')
+      jackhmmer_mgnify_result = run_msa_tool(
+          msa_runner=self.jackhmmer_mgnify_runner,
           input_fasta_path=input_fasta_path,
-          msa_out_path=bfd_out_path,
-          msa_format='a3m',
+          msa_out_path=mgnify_out_path,
+          msa_format='sto',
           use_precomputed_msas=self.use_precomputed_msas,
-          max_sto_sequences=self.bfd_max_hits)
-      bfd_msa = parsers.parse_a3m(hhblits_bfd_uniref_result['a3m'])
+          max_sto_sequences=self.mgnify_max_hits)
+
+      msa_for_templates = jackhmmer_uniref90_result['sto']
+      msa_for_templates = parsers.deduplicate_stockholm_msa(msa_for_templates)
+      msa_for_templates = parsers.remove_empty_columns_from_stockholm_msa(
+          msa_for_templates)
+
+      pdb_hits_out_path = os.path.join(
+          msa_output_dir, f'pdb_hits.{self.template_searcher.output_format}')
+      if self.no_templates:
+        logging.info(f'Using no template information at all (--no_templates is {self.no_templates})')
+        pdb_template_hits=[]
+        pdb_templates_result=""
+      else:
+        if not self.use_precomputed_msas or not os.path.isfile(pdb_hits_out_path):
+          if self.template_searcher.input_format == 'sto':
+            pdb_templates_result = self.template_searcher.query(msa_for_templates)
+          elif self.template_searcher.input_format == 'a3m':
+            uniref90_msa_as_a3m = parsers.convert_stockholm_to_a3m(msa_for_templates)
+            pdb_templates_result = self.template_searcher.query(uniref90_msa_as_a3m)
+          else:
+            raise ValueError('Unrecognized template input format: '
+                          f'{self.template_searcher.input_format}')
+          with open(pdb_hits_out_path, 'w') as f:
+            f.write(pdb_templates_result)
+        else: # read a pre-existing pdb_hits.sto file
+          with open(pdb_hits_out_path) as f:
+            pdb_templates_result = f.read()
+        pdb_template_hits = self.template_searcher.get_template_hits(
+          output_string=pdb_templates_result, input_sequence=input_sequence)
+      
+
+      uniref90_msa = parsers.parse_stockholm(jackhmmer_uniref90_result['sto'])
+      mgnify_msa = parsers.parse_stockholm(jackhmmer_mgnify_result['sto'])
+
+      pdb_template_hits = self.template_searcher.get_template_hits(
+          output_string=pdb_templates_result, input_sequence=input_sequence)
+
+      if self._use_small_bfd:
+        bfd_out_path = os.path.join(msa_output_dir, 'small_bfd_hits.sto')
+        jackhmmer_small_bfd_result = run_msa_tool(
+            msa_runner=self.jackhmmer_small_bfd_runner,
+            input_fasta_path=input_fasta_path,
+            msa_out_path=bfd_out_path,
+            msa_format='sto',
+            use_precomputed_msas=self.use_precomputed_msas,
+            max_sto_sequences=self.bfd_max_hits)
+        bfd_msa = parsers.parse_stockholm(jackhmmer_small_bfd_result['sto'])
+      else:
+        bfd_out_path = os.path.join(msa_output_dir, 'bfd_uniref_hits.a3m')
+        hhblits_bfd_uniref_result = run_msa_tool(
+            msa_runner=self.hhblits_bfd_uniref_runner,
+            input_fasta_path=input_fasta_path,
+            msa_out_path=bfd_out_path,
+            msa_format='a3m',
+            use_precomputed_msas=self.use_precomputed_msas,
+            max_sto_sequences=self.bfd_max_hits)
+        bfd_msa = parsers.parse_a3m(hhblits_bfd_uniref_result['a3m'])
+
+      msa_features = make_msa_features((uniref90_msa, bfd_msa, mgnify_msa))
+    
+    else:
+      logging.info(f'Using provided MSA file {self.msa_file}')
+      with open(self.msa_file, 'r') as f:
+        result = {'a3m': f.read()}
+      a3m_msa = parsers.parse_a3m(result['a3m'])
+      msa_features = make_msa_features((a3m_msa, ))
+
+      if self.no_templates:
+        logging.info(f'Using no template information at all (--no_templates is {self.no_templates})')
+        pdb_template_hits=[]
+        pdb_templates_result=""
+      
+      pdb_template_hits = self.template_searcher.get_template_hits(
+          output_string=pdb_templates_result, input_sequence=input_sequence)
 
     templates_result = self.template_featurizer.get_templates(
-        query_sequence=input_sequence,
-        hits=pdb_template_hits)
-
+          query_sequence=input_sequence,
+          hits=pdb_template_hits)
+    
     sequence_features = make_sequence_features(
         sequence=input_sequence,
         description=input_description,
         num_res=num_res)
 
-    msa_features = make_msa_features((uniref90_msa, bfd_msa, mgnify_msa))
     #print(f"{pdb_template_hits}")
-    logging.info('Uniref90 MSA size: %d sequences.', len(uniref90_msa))
-    logging.info('BFD MSA size: %d sequences.', len(bfd_msa))
-    logging.info('MGnify MSA size: %d sequences.', len(mgnify_msa))
-    logging.info('Final (deduplicated) MSA size: %d sequences.',
-                 msa_features['num_alignments'][0])
-    logging.info('Total number of templates (NB: this can include bad '
-                 'templates and is later filtered to top 4): %d.',
-                 templates_result.features['template_domain_names'].shape[0])
+    if self.msa_file:
+      logging.info('Final (deduplicated) MSA size: %d sequences.',
+                  msa_features['num_alignments'][0])
+      logging.info('Total number of templates (NB: this can include bad '
+                  'templates and is later filtered to top 4): %d.',
+                  templates_result.features['template_domain_names'].shape[0])
+    else:
+      logging.info('Uniref90 MSA size: %d sequences.', len(uniref90_msa))
+      logging.info('BFD MSA size: %d sequences.', len(bfd_msa))
+      logging.info('MGnify MSA size: %d sequences.', len(mgnify_msa))
+      logging.info('Final (deduplicated) MSA size: %d sequences.',
+                  msa_features['num_alignments'][0])
+      logging.info('Total number of templates (NB: this can include bad '
+                  'templates and is later filtered to top 4): %d.',
+                  templates_result.features['template_domain_names'].shape[0])
 
     return {**sequence_features, **msa_features, **templates_result.features}

--- a/AF_multitemplate/alphafold/data/templates.py
+++ b/AF_multitemplate/alphafold/data/templates.py
@@ -805,6 +805,7 @@ class TemplateHitFeaturizer(abc.ABC):
       mmcif_dir: str,
       max_template_date: str,
       max_hits: int,
+      msa_file: str, 
       kalign_binary_path: str,
       release_dates_path: Optional[str],
       obsolete_pdbs_path: Optional[str],
@@ -832,10 +833,11 @@ class TemplateHitFeaturizer(abc.ABC):
         * If any template is a duplicate of the query.
         * Any feature computation errors.
     """
-    self._mmcif_dir = mmcif_dir
-    if not glob.glob(os.path.join(self._mmcif_dir, '*.cif')):
-      logging.error('Could not find CIFs in %s', self._mmcif_dir)
-      raise ValueError(f'Could not find CIFs in {self._mmcif_dir}')
+    if not msa_file:
+      self._mmcif_dir = mmcif_dir
+      if not glob.glob(os.path.join(self._mmcif_dir, '*.cif')):
+        logging.error('Could not find CIFs in %s', self._mmcif_dir)
+        raise ValueError(f'Could not find CIFs in {self._mmcif_dir}')
 
     try:
       self._max_template_date = datetime.datetime.strptime(
@@ -853,11 +855,12 @@ class TemplateHitFeaturizer(abc.ABC):
     else:
       self._release_dates = {}
 
-    if obsolete_pdbs_path:
-      logging.info('Using precomputed obsolete pdbs %s.', obsolete_pdbs_path)
-      self._obsolete_pdbs = _parse_obsolete(obsolete_pdbs_path)
-    else:
-      self._obsolete_pdbs = {}
+    if not msa_file:
+      if obsolete_pdbs_path:
+        logging.info('Using precomputed obsolete pdbs %s.', obsolete_pdbs_path)
+        self._obsolete_pdbs = _parse_obsolete(obsolete_pdbs_path)
+      else:
+        self._obsolete_pdbs = {}
 
   @abc.abstractmethod
   def get_templates(

--- a/AF_multitemplate/alphafold/data/tools/hhsearch.py
+++ b/AF_multitemplate/alphafold/data/tools/hhsearch.py
@@ -33,6 +33,7 @@ class HHSearch:
                *,
                binary_path: str,
                databases: Sequence[str],
+               msa_file:str,
                maxseq: int = 1_000_000):
     """Initializes the Python HHsearch wrapper.
 
@@ -52,9 +53,10 @@ class HHSearch:
     self.maxseq = maxseq
 
     for database_path in self.databases:
-      if not glob.glob(database_path + '_*'):
-        logging.error('Could not find HHsearch database %s', database_path)
-        raise ValueError(f'Could not find HHsearch database {database_path}')
+      if not msa_file:
+        if not glob.glob(database_path + '_*'):
+          logging.error('Could not find HHsearch database %s', database_path)
+          raise ValueError(f'Could not find HHsearch database {database_path}')
 
   @property
   def output_format(self) -> str:

--- a/README.md
+++ b/README.md
@@ -78,13 +78,12 @@ python AF_multitemplate/run_afsample2.py --method afsample2 \
 		--output_dir examples/	
 
 ```
-Other useful flags (run ```<AF_multitemplate/run_alphafold.py --help>``` for more details)
+Other useful flags (run ```<AF_multitemplate/run_afsample2.py --help>``` for more details)
 | flag | Options | Usage |
 | --- | --- | --- |
-| --msa_perturbation_mode| random, profile | To choose MSA perturbation mode |
-| --use_precomputed_features| Bool| Whether to use precomputed features.pkl file |
-
-
+| --use_precomputed_features| Bool| Whether to use precomputed features file (msa_features.pkl). All database paths in flagfile will be ignored.|
+| --msa_file| path_to_msa | Single MSA file (e.g., .a3m from mmseqs2). All database paths in flagfile will be ignored. |
+| --msa_perturbation_mode| <random, profile> | To choose MSA perturbation mode |
 
 
 ###  Container usage usage


### PR DESCRIPTION
Addressing issue https://github.com/iamysk/AFsample2/issues/6

Added functionality (`--msa-file`) to provide single MSA file as input (.a3m format). Will ignore/won"t-check any database paths provided in flagfile. Also `--use_precomputed_features` for using pickle files as feature inputs will also ignore any databases. 

NOTE: Database paths can't be empty in the flag-file (replace db paths with None) while using `--msa-file` or `--use_precomputed_features` flags.
